### PR TITLE
Outdated B9 Switch

### DIFF
--- a/GameData/BDBNIC/Patches/PioneerAble.cfg
+++ b/GameData/BDBNIC/Patches/PioneerAble.cfg
@@ -14,7 +14,7 @@
 		}
 		SUBTYPE
 		{
-			name = Thermal Control Pinwheels
+			name = Thermal Control Pinwheels (BDBNIC)
 			TEXTURE
 			{
 				texture = BDBNIC/ProbeExpansion/PioneerAble/bluedog_PioneerP3_P3


### PR DESCRIPTION
This switch is getting added to the main BDB version so it should be renamed (or eventually removed) to prevent B9 log errors.